### PR TITLE
Add logging to for passing test cases

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+log_cli = 1
+log_cli_level = INFO
+log_level = INFO
+junit_logging = all
+junit_log_passing_tests = 1

--- a/tests/QA/test_radio.py
+++ b/tests/QA/test_radio.py
@@ -9,6 +9,9 @@ from cflib.crtp.crtpstack import CRTPPacket
 from cflib.crtp.crtpstack import CRTPPort
 
 import conftest
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize('dev', conftest.get_devices(), ids=lambda d: d.name)
@@ -75,6 +78,8 @@ def latency(uri, packet_size=4, count=500):
 
     link.close()
     result = np.min(latencies)
+    logger.info('latency: {}'.format(result))
+
     return result
 
 
@@ -109,4 +114,6 @@ def bandwidth(uri, packet_size=4, count=500):
 
     link.close()
     result = count / (end_time - start_time)
+    logger.info('bandwidth: {}'.format(result))
+
     return result


### PR DESCRIPTION
With these magic `[pytest]` incantations in `pytest.ini` we will get the output from `logger.info()` in our junit-xml files.

We will also see them when tests run, for example:
```
 $ pytest --junit-xml=test.xml --verbose tests/QA/test_radio.py
```

Will show in the console:
```
[...]
tests/QA/test_radio.py::TestRadio::test_latency_small_packets[E7E7E7E702]
---------- live log call -------------
INFO     test_radio:test_radio.py:81 latency: 2.8858184814453125
PASSED
[...]
```
And in `test.xml`:
```
<testcase classname="..." name="test_latency_small_packets[E7E7E7E702]" time="1.864">
  <system-out>
    --------------------------------- Captured Log ---------------------------------
    #x1B[32mINFO    #x1B[0m test_radio:test_radio.py:81 latency: 2.8858184814453125
    --------------------------------- Captured Out ---------------------------------
  </system-out>
  <system-err>
    --------------------------------- Captured Err ---------------------------------
  </system-err>
</testcase>
```
