### PR TITLE
Add testing of swarms using Crazyswarm project

### DIFF
--- a/.github/workflows/crazylab-malmö.yml
+++ b/.github/workflows/crazylab-malmö.yml
@@ -39,7 +39,7 @@ jobs:
         run: python3 management/program.py --file nightly/firmware-cf2-nightly.zip
       
       - name: Run test suite
-        run: pytest --verbose --junit-xml $CRAZY_SITE-$(date +%s).xml
+        run: pytest --verbose --junit-xml $CRAZY_SITE-$(date +%s).xml tests/QA
 
       - name: Checkout Crazyflie python library
         uses: actions/checkout@v2

--- a/.github/workflows/crazyswarm-malmö.yml
+++ b/.github/workflows/crazyswarm-malmö.yml
@@ -1,0 +1,79 @@
+name: Crazyswarm test 🐝
+
+# Controls when the action will run.
+on:
+  workflow_dispatch:
+  schedule:
+  - cron:  '0 4 * * *'
+
+jobs:
+  swarm_at_crazylab:
+    runs-on: self-hosted
+    container:
+      image: ros:noetic
+      options: --privileged
+
+    env:
+      CSW_PYTHON: python3
+      CRAZYSWARM_PATH: crazyswarm
+      CRAZYSWARM_YAML: crazylab-malmö.yaml
+
+    steps:
+      - name: Update apt sources
+        run: |
+          echo "deb http://ports.ubuntu.com/ubuntu-ports focal main restricted" >> /etc/apt/sources.list
+          sudo apt-get update
+
+      - name: Install Crazyswarm dependencies
+        run: |
+          sudo apt-get install -y git swig libpython3-dev python3-numpy \
+          python3-yaml python3-matplotlib python3-pytest python3-scipy \
+          libpcl-dev libusb-1.0-0-dev sdcc ros-noetic-vrpn gcc-arm-none-eabi \
+          ros-noetic-tf ros-noetic-tf-conversions python3-toml python3-pip
+
+      - name: Check out sources
+        uses: actions/checkout@v2
+
+      - name: Download latest firmware files
+        with:
+          repo: bitcraze/crazyflie-release
+          workflow: nightly.yml
+        uses: dawidd6/action-download-artifact@v2.14.0
+
+      - name: Check out sources
+        uses: actions/checkout@v2
+
+      - name: Download latest firmware files
+        with:
+          repo: bitcraze/crazyflie-release
+          workflow: nightly.yml
+        uses: dawidd6/action-download-artifact@v2.14.0
+
+      - name: Checkout Crazyswarm
+        uses: actions/checkout@v2
+        with:
+          repository: USC-ACTLab/crazyswarm
+          path: crazyswarm
+
+      - name: Build Crazyswarm
+        run: |
+          source /opt/ros/noetic/setup.bash
+          cd crazyswarm
+          ./build.sh
+        shell: bash
+
+      - name: Install Crazyflie python library
+        run: pip3 install git+https://github.com/bitcraze/crazyflie-lib-python.git@master
+
+      - name: Upgrade swarm to latest firmware
+        run: |
+          source crazyswarm/ros_ws/devel/setup.bash
+          python3 management/program_swarm.py nightly/firmware-tag-nightly.zip --sim
+        shell: bash
+
+      - name: Run Crazyswarm tests
+        run: |
+          source crazyswarm/ros_ws/devel/setup.bash
+          roslaunch swarms/crazylab-malmö.launch &
+          python3 -m pytest --verbose tests/crazyswarm
+        shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,4 @@ repos:
     rev: 7192665e31cea6ace58a71e086c7248d7e5610c2
     hooks:
     -   id: flake8
+        args: [--ignore=E501]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See the file `sites/single-cf.toml` for the site file format to define new test 
 
 To run the test for a single Crazyflie, run:
 ```
-CRAZY_SITE=single-cf pytest --verbose
+CRAZY_SITE=single-cf pytest --verbose tests/QA
 ```
 
 If you have defined your own site, then change the `CRAZY_SITE` environment
@@ -32,4 +32,25 @@ management/program.py               - Flash a firmware file to devices in site
 management/bootloader_addresses.py  - List all devices bootloader addresses
 management/recover.py               - Attempt to recover one or all device(s)
                                       from bootloader mode
+management/program_swarm.py         - Flash a firmware file to devices in a swarm
+```
+
+## Testing with Crazyswarm
+It also possible to test using the [Crazyswarm](https://github.com/USC-ACTLab/crazyswarm) project.
+You will need to specify your swarm in `swarms/name.yaml` and a [ROS](https://www.ros.org/) launch file in `swarms/name.launch` you can check the `swarms/crazylab-malmö.[yaml|launch]` files for inspiration.
+
+To run the Crazyswarm tests or flash firmware files to a swarm you need to define some environment variables:
+
+```
+$ export CRAZYSWARM_PATH=[path to checked out crazyswarm source]
+$ export CRAZYSWARM_YAML=[name_of_your.yaml]
+
+$ source $CRAZYSWARM_PATH/ros_ws/devel/setup.bash
+$ roslaunch [path to your launch file] &
+
+# To flash all devices in swarm
+$ python3 management/program_swarm.py [firmware file]
+
+# To run the crazyswarm tests
+$ python3 -m pytest tests/crazyswarm
 ```

--- a/swarms/crazylab-malmö.launch
+++ b/swarms/crazylab-malmö.launch
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="joy_dev" default="/dev/input/js0" />
+
+  <rosparam command="load" file="$(find crazyswarm)/launch/crazyflieTypes.yaml" />
+  <rosparam command="load" file="swarms/crazylab-malmö.yaml" />
+
+  <node pkg="crazyswarm" type="crazyswarm_server" name="crazyswarm_server" output="screen" >
+    <rosparam>
+      world_frame: "/world"
+      # Logging configuration (Use enable_logging to actually enable logging)
+      genericLogTopics: ["log1"]
+      genericLogTopicFrequencies: [10]
+      genericLogTopic_log1_Variables: ["stateEstimate.x", "ctrltarget.x"]
+      firmwareParams:
+        commander:
+          enHighLevel: 1
+        stabilizer:
+          estimator: 1 # 1: complementary, 2: kalman
+          controller: 1 # 1: PID, 2: mellinger
+      # tracking
+      motion_capture_type: "none" # one of none,vicon,optitrack,qualisys,vrpn
+      object_tracking_type: "libobjecttracker" # one of motionCapture,libobjecttracker
+      send_position_only: True # set to False to send position+orientation; set to True to send position only
+      save_point_clouds: ~/pointCloud.ot
+      print_latency: False
+      write_csvs: False
+      force_no_cache: False
+      enable_parameters: True
+      enable_logging: False
+    </rosparam>
+  </node>
+</launch>

--- a/swarms/crazylab-malmö.yaml
+++ b/swarms/crazylab-malmö.yaml
@@ -1,0 +1,45 @@
+crazyflies:
+- id: 0xA1
+  channel: 42
+  initialPosition: [0.0, 0.0, 0.0]
+  type: default
+
+- id: 0xA2
+  channel: 42
+  initialPosition: [0.0, 0.0, 0.0]
+  type: default
+
+- id: 0xA3
+  channel: 42
+  initialPosition: [0.0, 0.0, 0.0]
+  type: default
+
+- id: 0xA4
+  channel: 42
+  initialPosition: [0.0, 0.0, 0.0]
+  type: default
+
+- id: 0xA5
+  channel: 42
+  initialPosition: [0.0, 0.0, 0.0]
+  type: default
+
+- id: 0xA7
+  channel: 42
+  initialPosition: [0.0, 0.0, 0.0]
+  type: default
+
+- id: 0xA8
+  channel: 42
+  initialPosition: [0.0, 0.0, 0.0]
+  type: default
+
+- id: 0xA9
+  channel: 42
+  initialPosition: [0.0, 0.0, 0.0]
+  type: default
+
+- id: 0xAA
+  channel: 42
+  initialPosition: [0.0, 0.0, 0.0]
+  type: default

--- a/tests/crazyswarm/test_crazy_swarm.py
+++ b/tests/crazyswarm/test_crazy_swarm.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2021 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+import pytest
+import logging
+import os
+import random
+import sys
+
+try:
+    crazyswarm_path = os.environ['CRAZYSWARM_PATH']
+    sys.path.append(
+        os.path.join(crazyswarm_path, 'ros_ws/src/crazyswarm/scripts')
+    )
+    sys.path.append(os.path.join(crazyswarm_path, 'ros_ws/src/crazyflie_ros'))
+    from pycrazyswarm import Crazyswarm
+except KeyError:
+    print('CRAZYSWARM_PATH or CRAZYSWARM_YAML not set', file=sys.stderr)
+    pytest.skip()
+except ImportError:
+    print('Failed to import pycrazyswarm', file=sys.stderr)
+    pytest.skip()
+
+logger = logging.getLogger(__name__)
+
+yaml = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    '../../swarms',
+    os.environ['CRAZYSWARM_YAML']
+)
+swarm = Crazyswarm(crazyflies_yaml=yaml)
+
+
+class TestCrazyswarm:
+    def test_get_cf_param(self):
+        '''Test that we can read parameters from all crazyflies in swarm'''
+        for cf in swarm.allcfs.crazyflies:
+            assert cf.getParam('stabilizer/estimator') == 1
+
+    def test_set_cf_param(self):
+        '''Test that we can set a param on a crazyflie and read it back'''
+        index = random.randrange(0, len(swarm.allcfs.crazyflies) - 1)
+        cf = swarm.allcfs.crazyflies[index]
+        cf.setParam('commander/enHighLevel', 0)
+
+        for i, cf in enumerate(swarm.allcfs.crazyflies):
+            if i == index:
+                assert cf.getParam('commander/enHighLevel') == 0
+            else:
+                assert cf.getParam('commander/enHighLevel') == 1
+        swarm.allcfs.setParam('commander/enHighLevel', 1)
+
+    # Should this work? It seems it doesn't @whoenig what is the deal?
+    # def test_set_cf_param_broadcast(self):
+    #     swarm.allcfs.setParam('stabilizer/controller', 2)
+    #     for cf in swarm.allcfs.crazyflies:
+    #         assert cf.getParam('stabilizer/controller') == 2
+    #     swarm.allcfs.setParam('stabilizer/controller', 1)


### PR DESCRIPTION
This PR adds testing of swarms, using the Crazyswarm project.

Crazyswarm is a project that complements the Bitcraze offering in a really
nice way and we want to make sure that it keeps working against the latest
versions of our offerings.

Included in this PR is support for using the Crazyswarm way to define and
describe swarms in your test lab.

We expect that Crazyswarm has been installed in a way compatible with
https://crazyswarm.readthedocs.io/en/latest/installation.html.

The new things added in this PR is:

* Two new environment variables
  * `CRAZYSWARM_PATH`: the path to the Crazyswarm sources
  * `CRAZYSWARM_YAML`: the name of the YAML file that describe your swarm (will search the `swarms/` directory)
  
* An YAML description of a swarm of 9 roadrunner tags: `swarms/crazylab-malmö.yaml`
  * These are located in the printer room at HQ, see image:
   <img src="https://user-images.githubusercontent.com/974401/124810906-28d88680-df62-11eb-8e2a-d81dd8c5a8f4.jpg " width=50% height=50%>

  * A launch file for the swarm: `swarms/crazylab-malmö-launch`

* A script to update the firmware of all devices in a swarm:
  * `management/program_swarm.py`

* Initial tests of Crazyswarm functionality:
  * `tests/crazyswarm/test_crazyswarm.py`

And also a new GitHub actions workflow that will do the following on a local
runner (our RPi4 in the Printer room in Malmö):

1. Download and use the offcial ROS docker image
2. Install Crazyswarm dependencies
3. Download the latest firmware files
4. Clone and build Crazyswarm from the official branch
5. Install Crazyflie python library
6. Upgrade all devices in our crazylab swarm to latest firmware	
7. Run the Crazyswarm tests
