### PR TITLE
Initial tests for persistent parameters

### DIFF
--- a/tests/QA/test_param.py
+++ b/tests/QA/test_param.py
@@ -15,6 +15,7 @@ import pytest
 import conftest
 import logging
 import time
+import random
 
 from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
 
@@ -58,6 +59,152 @@ class TestParameters:
             assert element is not None
             assert not element.is_extended()
             assert not element.is_persistent()
+
+    def test_param_persistent_store(self, test_setup):
+        # Get a known persistent parameter
+        param = 'sound.effect'
+
+        # Get a random valid value
+        value = random.randint(0, 13)
+
+        with SyncCrazyflie(test_setup.device.link_uri) as scf:
+            # Set Value
+            logger.info(f'Setting value {value} as {param}')
+            scf.cf.param.set_value(param, value)
+
+            time.sleep(2)
+
+            got_callback = False
+            def store_cb(name, success):
+                nonlocal got_callback
+                assert name == param
+                assert success
+
+                got_callback = True
+
+            scf.cf.param.persistent_store(param, store_cb)
+            tries = 5
+            while not got_callback and tries > 0:
+                time.sleep(1)
+                tries -= 1
+            assert got_callback
+
+            test_setup.device.reboot()
+
+        # Allow time to reboot
+        time.sleep(5)
+        got_callback = False
+
+        with SyncCrazyflie(test_setup.device.link_uri) as scf:
+            [group, name] = param.split('.')
+
+            def param_cb(name: str, val: str):
+                nonlocal got_callback
+
+                assert name == param
+                assert int(val) == value
+                got_callback = True
+
+            scf.cf.param.add_update_callback(
+                group=group,
+                name=name,
+                cb=param_cb
+            )
+
+            tries = 5
+            while not got_callback and tries > 0:
+                time.sleep(1)
+                tries -= 1
+            assert got_callback
+
+    def test_param_persistent_clear(self, test_setup):
+        with SyncCrazyflie(test_setup.device.link_uri) as scf:
+            # Get a known persistent parameter
+            param = 'sound.effect'
+
+            gotten_state = False
+
+            def clear_cb(name, success):
+                assert name == param
+                assert success
+
+            def state_cb_1(name, state):
+                nonlocal gotten_state
+
+                assert name == param
+
+                assert state is not None
+                assert isinstance(state.is_stored, bool)
+                assert state.default_value == 0
+                if state.is_stored:
+                    scf.cf.param.persistent_clear(param, clear_cb)
+                    assert state.stored_value is not None
+                else:
+                    assert state.stored_value is None
+
+                gotten_state = True
+
+            scf.cf.param.persistent_get_state(param, state_cb_1)
+            tries = 5
+            while not gotten_state and tries > 0:
+                time.sleep(1)
+                tries -= 1
+            assert gotten_state
+
+             # Allow time to reboot
+            time.sleep(5)
+            gotten_state = False
+
+            def state_cb_2(name, state):
+                nonlocal gotten_state
+
+                assert name == param
+                assert state is not None
+                assert isinstance(state.is_stored, bool)
+                assert not state.is_stored
+                gotten_state = True
+
+            scf.cf.param.persistent_get_state(param, state_cb_2)
+            tries = 5
+            while not gotten_state and tries > 0:
+                time.sleep(1)
+                tries -= 1
+            assert gotten_state
+
+    def test_param_persistent_get_state(self, test_setup):
+        with SyncCrazyflie(test_setup.device.link_uri) as scf:
+            # Get a known persistent parameter
+            param = 'sound.effect'
+
+            gotten_state = False
+
+            def state_cb(name, state):
+                nonlocal gotten_state
+
+                assert name == param
+                assert state is not None
+                logger.info(f'state: {state}')
+                assert isinstance(state.is_stored, bool)
+                assert state.default_value == 0
+                if state.is_stored:
+                    assert state.stored_value is not None
+                else:
+                    assert state.stored_value is None
+
+                gotten_state = True
+
+            scf.cf.param.persistent_get_state(param, state_cb)
+            tries = 5
+            while not gotten_state and tries > 0:
+                time.sleep(1)
+                tries -= 1
+            assert gotten_state
+
+            # Attempt to get state from non-persistent param,
+            # make sure we get AttributeError.
+            param = "stabilizer.stop"
+            with pytest.raises(AttributeError):
+                scf.cf.param.persistent_get_state(param, state_cb)
 
     def test_param_set_raw(self, test_setup):
         param = 'ring.effect'

--- a/tests/QA/test_param.py
+++ b/tests/QA/test_param.py
@@ -42,6 +42,23 @@ class TestParameters:
             with pytest.raises(AttributeError):
                 scf.cf.param.set_value(param, 1)
 
+    def test_param_extended_type(self, test_setup):
+        with SyncCrazyflie(test_setup.device.link_uri) as scf:
+            # Get a known persistent parameter
+            param = 'ring.effect'
+            element = scf.cf.param.toc.get_element_by_complete_name(param)
+            assert element is not None
+            assert element.is_extended()
+            assert element.is_persistent()
+
+            # And a known non-persistent parameter
+            param = 'stabilizer.stop'
+            element = scf.cf.param.toc.get_element_by_complete_name(param)
+            print(element.is_persistent)
+            assert element is not None
+            assert not element.is_extended()
+            assert not element.is_persistent()
+
     def test_param_set_raw(self, test_setup):
         param = 'ring.effect'
         value = 13  # Gravity effect


### PR DESCRIPTION
- test_param: Add test of extended parameter types
- test_param: Add test of persistent_get_state()

Edit `sites/single-cf.toml` to add your cf and run as:
```
CRAZY_SITE=single-cf pytest-3 -s  tests/QA/test_param.py -k test_param_persistent
```

Needs the jonasdn/persistent_parameters branch on crazyflie-lib-python as well