### PR TITLE
2 hour stablab timeouts

### DIFF
--- a/.github/workflows/crazylab-malmö-experiment.yml
+++ b/.github/workflows/crazylab-malmö-experiment.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   testsuite_at_crazylab:
     runs-on: self-hosted
+    timeout-minutes: 120
     container:
       image: python:3.9.7-buster
       options: --privileged

--- a/.github/workflows/crazylab-malmö.yml
+++ b/.github/workflows/crazylab-malmö.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   testsuite_at_crazylab:
     runs-on: self-hosted
+    timeout-minutes: 1
     container:
       image: python:3.9.7-buster
       options: --privileged

--- a/.github/workflows/crazylab-malmö.yml
+++ b/.github/workflows/crazylab-malmö.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   testsuite_at_crazylab:
     runs-on: self-hosted
-    timeout-minutes: 1
+    timeout-minutes: 120
     container:
       image: python:3.9.7-buster
       options: --privileged


### PR DESCRIPTION
Introduces a 2 hour timeout to the Stab Lab and Stab Lab Experment actions

Tested successfully with a 1 minute timeout in [actions/runs/8343667855](https://github.com/bitcraze/crazyflie-testing/actions/runs/8343667855)
