### PR TITLE
Reboot after failing a test

### DIFF
--- a/tests/QA/test_param.py
+++ b/tests/QA/test_param.py
@@ -17,19 +17,10 @@ import logging
 import time
 import random
 from threading import Event
-from functools import wraps
+from utils.wrappers import reboot_wrapper
 
 from conftest import ValidatedSyncCrazyflie
 
-def reboot_wrapper(func):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        try:
-            func(*args, **kwargs)
-        except:
-            kwargs['test_setup'].device.reboot()
-            raise
-    return wrapper
 
 logger = logging.getLogger(__name__)
 
@@ -211,6 +202,7 @@ class TestParameters:
                 scf.cf.param.persistent_get_state(param, state_cb)
 
 
+    @reboot_wrapper
     def test_param_persistent_eeprom_stress(self, test_setup: conftest.DeviceFixture):
         """ Stress test the eeprom by setting and clearing persistent parameters. This will create holes in the eeprom
             memory which needs to be de-fragmented once it hits this limit, which should be between 250-300 persistent

--- a/tests/QA/test_param.py
+++ b/tests/QA/test_param.py
@@ -17,8 +17,19 @@ import logging
 import time
 import random
 from threading import Event
+from functools import wraps
 
 from conftest import ValidatedSyncCrazyflie
+
+def reboot_wrapper(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except:
+            kwargs['test_setup'].device.reboot()
+            raise
+    return wrapper
 
 logger = logging.getLogger(__name__)
 

--- a/utils/wrappers.py
+++ b/utils/wrappers.py
@@ -1,0 +1,15 @@
+from functools import wraps
+from time import sleep
+
+def reboot_wrapper(func):
+    """Decorator to reboot the device if an exception is raised in the decorated function."""
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except:
+            sleep(5)  # wait for assert-induced reboot into error state
+            kwargs['test_setup'].device.reboot()
+            sleep(5)  # wait for reboot
+            raise
+    return wrapper


### PR DESCRIPTION
Although ideally the tests should consistently pass, it would be nice if the rest of the tests can continue regardless of the result of the previous tests. To address this I thought the most logical way forward was to reboot the Crazyflie after encountering the failed test.

For that I've created a Python wrapper that has to be specifically applied to a test where you want this rebooting behavior.