### PR TITLE
Update versions for node update

### DIFF
--- a/.github/workflows/crazylab-malmö-experiment.yml
+++ b/.github/workflows/crazylab-malmö-experiment.yml
@@ -32,7 +32,7 @@ jobs:
         run: pip3 install git+https://github.com/bitcraze/crazyflie-lib-python.git@master
 
       - name: Check out sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install requirements
         run: pip3 install -r requirements.txt
@@ -41,7 +41,7 @@ jobs:
         with:
           repo: bitcraze/crazyflie-release
           workflow: nightly-experiment.yml
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v3
 
       - name: Reset power to all devices
         run: python3 management/usb-power-reset.py -a reset

--- a/.github/workflows/crazylab-malmö.yml
+++ b/.github/workflows/crazylab-malmö.yml
@@ -32,7 +32,7 @@ jobs:
         run: pip3 install git+https://github.com/bitcraze/crazyflie-lib-python.git@master
 
       - name: Check out sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install requirements
         run: pip3 install -r requirements.txt
@@ -41,7 +41,7 @@ jobs:
         with:
           repo: bitcraze/crazyflie-release
           workflow: nightly.yml
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v3
 
       - name: Reset power to all devices
         run: python3 management/usb-power-reset.py -a reset
@@ -53,7 +53,7 @@ jobs:
         run: pytest --verbose --junit-xml $CRAZY_SITE-$(date +%s).xml tests/QA
 
       - name: Checkout Crazyflie python library
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: bitcraze/crazyflie-lib-python
           path: crazyflie-lib-python

--- a/.github/workflows/crazyswarm-malmö.yml
+++ b/.github/workflows/crazyswarm-malmö.yml
@@ -28,16 +28,16 @@ jobs:
           ros-noetic-tf ros-noetic-tf-conversions python3-toml python3-pip
 
       - name: Check out sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download latest firmware files
         with:
           repo: bitcraze/crazyflie-release
           workflow: nightly.yml
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v3
 
       - name: Checkout Crazyswarm
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: USC-ACTLab/crazyswarm
           path: crazyswarm


### PR DESCRIPTION
Update action versions to use latest ones. 

This is due to node.js 16 deprecation. We should use 
actions that run node.js 20