### PR TITLE
Add Test summary and push output file to github

### DIFF
--- a/.github/workflows/crazylab-malmö-experiment.yml
+++ b/.github/workflows/crazylab-malmö-experiment.yml
@@ -8,13 +8,14 @@ on:
 
 jobs:
   testsuite_at_crazylab:
+    env:
+      CRAZY_SITE: crazylab-malmö
+      TEST_FILE: TestRun-${{github.run_number}}.xml
     runs-on: self-hosted
     timeout-minutes: 120
     container:
       image: python:3.9.7-buster
       options: --privileged
-    env:
-      CRAZY_SITE: crazylab-malmö
     steps:
       - name: Install libusb
         run: |
@@ -50,4 +51,18 @@ jobs:
         run: python3 management/program.py --file nightly-experiment/firmware-cf2-nightly-experiment.zip
 
       - name: Run test suite
-        run: pytest --verbose --junit-xml $CRAZY_SITE-$(date +%s).xml tests/QA
+        run: pytest --verbose --junit-xml ${{env.TEST_FILE}} tests/QA/test_param.py
+
+      - name: Upload test file
+        uses: actions/upload-artifact@v4
+        with:
+          name: test_report
+          path: ${{env.TEST_FILE}}
+
+      - name: Pretty print test results
+        if: always()
+        uses: pmeier/pytest-results-action@main
+        with:
+          path: ${{env.TEST_FILE}}
+          summary: true
+          title: Test results

--- a/.github/workflows/crazylab-malmö.yml
+++ b/.github/workflows/crazylab-malmö.yml
@@ -15,6 +15,7 @@ jobs:
       options: --privileged
     env:
       CRAZY_SITE: crazylab-malmö
+      TEST_FILE: TestRun-${{github.run_number}}.xml
     steps:
       - name: Install libusb
         run: |
@@ -50,7 +51,7 @@ jobs:
         run: python3 management/program.py --file nightly/firmware-cf2-nightly.zip
 
       - name: Run test suite
-        run: pytest --verbose --junit-xml $CRAZY_SITE-$(date +%s).xml tests/QA
+        run: pytest --verbose --junit-xml ${{env.TEST_FILE}} tests/QA
 
       - name: Checkout Crazyflie python library
         uses: actions/checkout@v3
@@ -64,3 +65,18 @@ jobs:
       - name: Run Crazyflie python library examples
         run: |
           python3 -u utils/run_examples.py --path crazyflie-lib-python
+
+      - name: Upload test file
+        uses: actions/upload-artifact@v4
+        with:
+          name: test_report
+          path: ${{env.TEST_FILE}}
+  
+      - name: Pretty print test results
+        if: always()
+        uses: pmeier/pytest-results-action@main
+        with:
+          path: ${{env.TEST_FILE}}
+          summary: true
+          title: Test results
+


### PR DESCRIPTION
The action pytest-results-action will create a nice summary of test time and number of failed/skipped/passed tests.

Added a step to also publish the xml test file to github as an artefact. It will stay for 90 days. If we want to keep it longer we need our own database. However that can be added later.