### PR TITLE
Add runtime parameters to stab lab experiment

### DIFF
--- a/.github/workflows/crazylab-malmö-experiment.yml
+++ b/.github/workflows/crazylab-malmö-experiment.yml
@@ -5,11 +5,13 @@ on:
   workflow_dispatch:
     inputs:
       category:
+        type: string
         description: 'Test category.' #Format: tests/.../test_*.py'
       filter:
+        type: string
         description: 'Select a filter to filter the tests on' #NOTE to filter on more than one test, use the following syntax: -k "filter1 or filter2"
-        default: ''
       devices:
+        type: string
         description: 'Devices to run the tests on.' #Format: <device1>,<device2>,...'
 
 #  schedule:
@@ -59,11 +61,17 @@ jobs:
 
       - name: Upgrade devices to latest firmware
         run: python3 management/program.py --file nightly-experiment/firmware-cf2-nightly-experiment.zip
-
       - name: Run test suite
-        
-        run: pytest --verbose --junit-xml ${{env.TEST_FILE}} ${{github.event.inputs.category}} -k ${{github.event.inputs.filter}}
-
+        env:
+          FILTER: ${{ github.event.inputs.filter || '""'}}
+        run: |
+          FILTER_INPUT="${{ github.event.inputs.filter }}"
+          FILTER_OPTION=$(echo "$FILTER_INPUT" | xargs)  # Trim spaces and check for non-empty content
+          if [ -n "$FILTER_OPTION" ]; then
+            pytest --verbose --junit-xml ${{env.TEST_FILE}} ${{github.event.inputs.category}} -k ${{ github.event.inputs.filter }}
+          else
+            pytest --verbose --junit-xml ${{env.TEST_FILE}} ${{github.event.inputs.category}} 
+          fi
       - name: Upload test file
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/crazylab-malmö-experiment.yml
+++ b/.github/workflows/crazylab-malmö-experiment.yml
@@ -5,12 +5,12 @@ on:
   workflow_dispatch:
     inputs:
       category:
-        description: 'Select the test category to run. NOTE: the cateory is an actual filepath to a test file, starting with tests/.../test_*.py'
+        description: 'Test category.' #Format: tests/.../test_*.py'
       filter:
         description: 'Select a filter to filter the tests on' #NOTE to filter on more than one test, use the following syntax: -k "filter1 or filter2"
         default: ''
-      #deck:
-       # description: 'Select a deck to run the tests on'
+      devices:
+        description: 'Devices to run the tests on.' #Format: <device1>,<device2>,...'
 
 #  schedule:
 #  - cron:  '0 6 * * *'
@@ -20,6 +20,7 @@ jobs:
     env:
       CRAZY_SITE: crazylab-malmö
       TEST_FILE: TestRun-${{github.run_number}}.xml
+      CRAZY_DEVICE: ${{github.event.inputs.devices}}
     runs-on: self-hosted
     timeout-minutes: 120
     container:

--- a/.github/workflows/crazylab-malmö-experiment.yml
+++ b/.github/workflows/crazylab-malmö-experiment.yml
@@ -3,6 +3,15 @@ name: Crazy Stab Lab experiment 🗡️
 # Controls when the action will run.
 on:
   workflow_dispatch:
+    inputs:
+      category:
+        description: 'Select the test category to run. NOTE: the cateory is an actual filepath to a test file, starting with tests/.../test_*.py'
+      filter:
+        description: 'Select a filter to filter the tests on' #NOTE to filter on more than one test, use the following syntax: -k "filter1 or filter2"
+        default: ''
+      #deck:
+       # description: 'Select a deck to run the tests on'
+
 #  schedule:
 #  - cron:  '0 6 * * *'
 
@@ -51,7 +60,8 @@ jobs:
         run: python3 management/program.py --file nightly-experiment/firmware-cf2-nightly-experiment.zip
 
       - name: Run test suite
-        run: pytest --verbose --junit-xml ${{env.TEST_FILE}} tests/QA/test_param.py
+        
+        run: pytest --verbose --junit-xml ${{env.TEST_FILE}} ${{github.event.inputs.category}} -k ${{github.event.inputs.filter}}
 
       - name: Upload test file
         uses: actions/upload-artifact@v4

--- a/conftest.py
+++ b/conftest.py
@@ -263,19 +263,21 @@ def get_devices() -> List[BCDevice]:
     devices = list()
 
     site = os.getenv('CRAZY_SITE')
+    devicenames = os.getenv('CRAZY_DEVICE')
     if site is None:
         raise Exception('No CRAZY_SITE env specified!')
-
+    if devicenames is not None:
+        devicenames = devicenames.split(',')
     path = ""
     try:
         path = os.path.join(SITE_PATH, '%s.toml' % site)
         site_t = toml.load(open(path, 'r'))
 
         for name, device in site_t['device'].items():
-            devices.append(BCDevice(name, device))
+            if(not devicenames or name in devicenames):
+                devices.append(BCDevice(name, device))
     except Exception:
         raise Exception('Failed to parse toml %s!' % path)
-
     return devices
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -266,7 +266,7 @@ def get_devices() -> List[BCDevice]:
     devicenames = os.getenv('CRAZY_DEVICE')
     if site is None:
         raise Exception('No CRAZY_SITE env specified!')
-    if devicenames is not None:
+    if devicenames is not None and devicenames != '':
         devicenames = devicenames.split(',')
     path = ""
     try:


### PR DESCRIPTION
You can now filter tests on regex filter, file and device.

The device is an environment variable, (it can be left out and then is not used)

When starting a workflow on the experiment action this dialog will pop up. It can be left empty or filled. 
![Screenshot from 2024-06-25 16-56-00](https://github.com/bitcraze/crazyflie-testing/assets/45783739/1f820fcc-d70a-492d-b0e8-185f0cf59285)
