### PR TITLE
Toverumar/add device manager

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -34,12 +34,14 @@ def pytest_generate_tests(metafunc):
     has_properties = metafunc.definition.get_closest_marker('requirements')
     has_decks = has_decks.args if has_decks else []
     has_properties = has_properties.args if has_properties else []
-    
+
     devices = get_devices(has_decks,has_properties)
-    if 'test_setup' in metafunc.fixturenames:
-        metafunc.parametrize('test_setup', devices, indirect=True, ids=lambda d: d.name)
+    if devices:
+        param_name = 'test_setup' if 'test_setup' in metafunc.fixturenames else 'dev'
+        metafunc.parametrize(param_name, devices, indirect=True if param_name == 'test_setup' else False, ids=lambda d: d.name)
     else:
-        metafunc.parametrize('dev', devices, ids=lambda d: d.name)
+        print(f'No devices found for test {metafunc.definition.name}')
+        metafunc.parametrize("test_setup", [pytest.param(None, marks=pytest.mark.skip(reason="No device for test"))]) #This is a bit overly complicated but pytest.skip will skip all tests in module
 
 class USB_Power_Control_Action(str, Enum):
     ON     = 'on'

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,6 @@ log_cli_level = INFO
 log_level = INFO
 junit_logging = all
 junit_log_passing_tests = 1
+markers = 
+    decks: decks that a test needs to run
+    requirements: other requirements that a test needs to run

--- a/tests/QA/test_bootloaders.py
+++ b/tests/QA/test_bootloaders.py
@@ -16,7 +16,7 @@ import conftest
 import time
 
 
-@pytest.mark.parametrize('dev', conftest.get_devices(), ids=lambda d: d.name)
+
 class TestBootloaders:
 
     @staticmethod

--- a/tests/QA/test_decks.py
+++ b/tests/QA/test_decks.py
@@ -23,14 +23,9 @@ from cflib.crazyflie.syncLogger import SyncLogger
 # get_devices() will be passed to test_setup() in conftest.py before being used
 # as a parameter in the test methods.
 #
-@pytest.mark.parametrize(
-    'test_setup',
-    conftest.get_devices(),
-    indirect=True,
-    ids=lambda d: d.name
-)
-class TestDecks:
 
+class TestDecks:
+    @pytest.mark.parametrize('test_setup', conftest.get_devices(), indirect=True,ids=lambda d: d.name)
     def test_deck_present(self, test_setup: conftest.DeviceFixture):
         '''
         Check that all decks defined for the device in the site
@@ -45,14 +40,12 @@ class TestDecks:
             is_deck_present = int(test_setup.device.cf.param.get_value(f'deck.{deck}'))
             assert is_deck_present
 
-
+    @pytest.mark.parametrize('test_setup', conftest.get_devices(has_decks=["bcDWM1000"]), indirect=True,ids=lambda d: d.name)
     def test_loco_deck_loop_is_running(self, test_setup: conftest.DeviceFixture):
         '''
         Check that the event loop in the loco deck driver is running, this is indicated by read and writes to the SPI
         bus.
         '''
-        if not test_setup.has_loco_deck:
-            pytest.skip('Only on loco decks')
 
         assert test_setup.device.connect_sync()
 

--- a/tests/QA/test_decks.py
+++ b/tests/QA/test_decks.py
@@ -25,7 +25,7 @@ from cflib.crazyflie.syncLogger import SyncLogger
 #
 
 class TestDecks:
-    @pytest.mark.parametrize('test_setup', conftest.get_devices(), indirect=True,ids=lambda d: d.name)
+
     def test_deck_present(self, test_setup: conftest.DeviceFixture):
         '''
         Check that all decks defined for the device in the site
@@ -40,7 +40,8 @@ class TestDecks:
             is_deck_present = int(test_setup.device.cf.param.get_value(f'deck.{deck}'))
             assert is_deck_present
 
-    @pytest.mark.parametrize('test_setup', conftest.get_devices(has_decks=["bcDWM1000"]), indirect=True,ids=lambda d: d.name)
+
+    @pytest.mark.decks("bcDWM1000")
     def test_loco_deck_loop_is_running(self, test_setup: conftest.DeviceFixture):
         '''
         Check that the event loop in the loco deck driver is running, this is indicated by read and writes to the SPI

--- a/tests/QA/test_log.py
+++ b/tests/QA/test_log.py
@@ -21,20 +21,6 @@ from cflib.crazyflie.log import LogConfig
 from conftest import ValidatedSyncCrazyflie
 from cflib.crazyflie.syncLogger import SyncLogger
 
-
-#
-# Using the indirect=True parameter when parametrizing a test allows to
-# parametrize a test with a fixture receiving the values before passing them to
-# a test. In this case it means a device in the array returned from
-# get_devices() will be passed to test_setup() in conftest.py before being used
-# as a parameter in the test methods.
-#
-@pytest.mark.parametrize(
-    'test_setup',
-    conftest.get_devices(),
-    indirect=True,
-    ids=lambda d: d.name
-)
 class TestLogVariables:
 
     def test_log_async(self, test_setup: conftest.DeviceFixture):

--- a/tests/QA/test_mem.py
+++ b/tests/QA/test_mem.py
@@ -17,13 +17,6 @@ import conftest
 from cflib.crazyflie.mem import MemoryElement
 
 
-@pytest.mark.parametrize(
-    'test_setup',
-    conftest.get_devices(),
-    indirect=['test_setup'],
-    ids=lambda d: d.name
-)
-
 class TestMem:
     def test_mem_ow(self, test_setup: conftest.DeviceFixture):
         '''

--- a/tests/QA/test_param.py
+++ b/tests/QA/test_param.py
@@ -25,19 +25,6 @@ from conftest import ValidatedSyncCrazyflie
 logger = logging.getLogger(__name__)
 
 
-#
-# Using the indirect=True parameter when parametrizing a test allows to
-# parametrize a test with a fixture receiving the values before passing them to
-# a test. In this case it means a device in the array returned from
-# get_devices() will be passed to test_setup() in conftest.py before being used
-# as a parameter in the test methods.
-#
-@pytest.mark.parametrize(
-    'test_setup',
-    conftest.get_devices(),
-    indirect=True,
-    ids=lambda d: d.name
-)
 class TestParameters:
     def test_param_ronly(self, test_setup: conftest.DeviceFixture):
         with ValidatedSyncCrazyflie(test_setup.device.link_uri) as scf:

--- a/tests/QA/test_radio.py
+++ b/tests/QA/test_radio.py
@@ -27,7 +27,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize('dev', conftest.get_devices(), ids=lambda d: d.name)
 class TestRadio:
     def test_latency_small_packets(self, dev: conftest.BCDevice):
         requirement = conftest.get_requirement('radio.latencysmall')


### PR DESCRIPTION
This PR fixes skipping of tests at runtime if the test can only run on a specific deck. 

It is part of a bigger plan to manage test dependencies. Some of it is implemented in this PR. 
This PR implements;

- Move control of parameterizing tests to conftest, instead of behind the scenes
- Introduce "markers" which defines decks and requirements for tests.
- Introduce filtering of available decks during parametrization. The get_devices function can be called with lists of decks and/or requirements that it needs to run. (As of now a test will need all specified decks and requirements, however this might change later to be able to supply required combinations etc). 
- A test will be skipped if it can not find a suitable deck/requirement device (this is not handled super pretty but pytest.skip() seemed to not work as expected in this scenario, I will post a discussion to pytest people for this)
- All possible devices will now be tested. 