### PR TITLE
Add flowcontrol requirement so that tests that need it will not get generated for devices that do not have it

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -37,13 +37,14 @@ def pytest_generate_tests(metafunc):
     has_properties = has_properties.args if has_properties else []
     exclude_decks = exclude_decks.args if exclude_decks else []
     devices = get_devices(has_decks,has_properties, exclude_decks)
-    if devices:
-        param_name = 'test_setup' if 'test_setup' in metafunc.fixturenames else 'dev'
-        metafunc.parametrize(param_name, devices, indirect=True if param_name == 'test_setup' else False, ids=lambda d: d.name)
-    else:
-        print(f'No devices found for test {metafunc.definition.name}')
-        metafunc.parametrize("test_setup", [pytest.param(None, marks=pytest.mark.ignore(reason="No device for test"))]) #This is a bit overly complicated but pytest.skip will skip all tests in module
-
+    for fixture in metafunc.fixturenames:
+        if fixture == 'request':
+            continue
+        if devices:
+            metafunc.parametrize(fixture, devices, indirect=(fixture=='test_setup') , ids=lambda d: d.name)
+        else:
+            print(f'No devices found for test {metafunc.definition.name}')
+            metafunc.parametrize(fixture, [pytest.param(None, marks=pytest.mark.ignore(reason="No device for test"))]) #This is a bit overly complicated but pytest.skip will skip all tests in modul
 
 def pytest_collection_modifyitems(config, items):
 

--- a/tests/QA/test_radio.py
+++ b/tests/QA/test_radio.py
@@ -36,17 +36,18 @@ class TestRadio:
         requirement = conftest.get_requirement('radio.latencybig')
         assert(latency(dev.link_uri, requirement['packet_size']) < requirement['limit_high_ms'])
 
-    @pytest.mark.skip(reason='This test does not pass reliably. We need flow control between nrf and stm32')
+    @pytest.mark.requirements("syslink_flowctrl")
     def test_bandwidth_small_packets(self, dev: conftest.BCDevice):
         requirement = conftest.get_requirement('radio.bwsmall')
         assert(bandwidth(dev.link_uri, requirement['packet_size']) > requirement['limit_low'])
 
-    @pytest.mark.skip(reason='This test does not pass reliably. We need flow control between nrf and stm32')
+    @pytest.mark.requirements("syslink_flowctrl")
     def test_bandwidth_big_packets(self, dev: conftest.BCDevice):
         requirement = conftest.get_requirement('radio.bwbig')
         assert(bandwidth(dev.link_uri, requirement['packet_size']) > requirement['limit_low'])
 
-    @pytest.mark.skip(reason='This test does not pass reliably. We need flow control between nrf and stm32')
+    
+    @pytest.mark.requirements("syslink_flowctrl")
     def test_reliability(self, dev: conftest.BCDevice):
         requirement = conftest.get_requirement('radio.reliability')
         # The bandwidth function will assert if there is any packet loss


### PR DESCRIPTION
Right now, this is the only requirement we have. 

However once we get more the idea is to create a yaml file where you can define types. 
In this case CF2.1 and this type has several different properties. 

Then this type will be set in the site yaml file for each device. 

This will get rid of having skipped tests in each run. 