### PR TITLE
Python & Debian bump

### DIFF
--- a/.github/workflows/crazylab-linux-experiment.yml
+++ b/.github/workflows/crazylab-linux-experiment.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: [self-hosted, linux]
     timeout-minutes: 120
     container:
-      image: python:3.9.7-buster
+      image: python:3.13.0-bookworm
       options: --privileged
     steps:
       - name: Install libusb

--- a/.github/workflows/crazylab-linux.yml
+++ b/.github/workflows/crazylab-linux.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [self-hosted, linux]
     timeout-minutes: 120
     container:
-      image: python:3.9.7-buster
+      image: python:3.13.0-bookworm
       options: --privileged
     env:
       CRAZY_SITE: crazylab-malmö

--- a/.github/workflows/crazylab-sanity.yml
+++ b/.github/workflows/crazylab-sanity.yml
@@ -86,7 +86,7 @@ jobs:
       PYTHON_VERSION: ${{ matrix.python_version }}
     timeout-minutes: 120
     container:
-      image: python:${{ matrix.python_version }}-bullseye
+      image: python:${{ matrix.python_version }}-bookworm
       options: --privileged
     steps:
     - name: Upgrade pip

--- a/.github/workflows/crazylab-sanity.yml
+++ b/.github/workflows/crazylab-sanity.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: [self-hosted, macOS]
     strategy:
       matrix:
-        python_version: ["3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     env:
       TEST_FILE: Mac__sanity_test_job-${{github.run_number}}-${{ matrix.python_version }}
@@ -77,7 +77,7 @@ jobs:
     runs-on: [self-hosted, linux]
     strategy:
       matrix:
-        python_version: ["3.8","3.9", "3.10", "3.11","3.12"]
+        python_version: ["3.10", "3.11","3.12", "3.13"]
       fail-fast: false
     env:
       TEST_FILE: Linux_sanity_test_job-${{github.run_number}}-${{ matrix.python_version }}


### PR DESCRIPTION
- Bump supported Python versions (3.10-3.13)
- Use Debian Bookworm instead of Buster
- Run main tests on Python 3.13.0, the latest supported version.