### PR TITLE
Allow cancelling of GitHub workflows

### DIFF
--- a/.github/workflows/crazylab-linux-experiment.yml
+++ b/.github/workflows/crazylab-linux-experiment.yml
@@ -87,7 +87,7 @@ jobs:
             pytest --verbose --html=${{env.TEST_FILE}}.html ${{github.event.inputs.category}} --junit-xml ${{env.TEST_FILE}}.xml
           fi
       - name: Upload test file
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: warn
@@ -98,7 +98,7 @@ jobs:
             assets/style.css
 
       - name: Pretty print test results
-        if: always()
+        if: ${{ !cancelled() }}
         uses: pmeier/pytest-results-action@main
         with:
           path: ${{env.TEST_FILE}}.xml

--- a/.github/workflows/crazylab-linux.yml
+++ b/.github/workflows/crazylab-linux.yml
@@ -67,7 +67,7 @@ jobs:
           python3 -u utils/run_examples.py --path crazyflie-lib-python
 
       - name: Upload test file
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: warn
@@ -79,7 +79,7 @@ jobs:
 
   
       - name: Pretty print test results
-        if: always()
+        if: ${{ !cancelled() }}
         uses: pmeier/pytest-results-action@main
         with:
           path: ${{env.TEST_FILE}}.xml

--- a/.github/workflows/crazylab-sanity.yml
+++ b/.github/workflows/crazylab-sanity.yml
@@ -53,7 +53,7 @@ jobs:
         run: venv/bin/python -m pytest --verbose --html=${{env.TEST_FILE}}.html --junit-xml ${{env.TEST_FILE}}.xml -m sanity tests/QA
 
       - name: Upload test file
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{env.TEST_FILE}}_results
@@ -64,7 +64,7 @@ jobs:
             assets/style.css
 
       - name: Pretty print test results
-        if: always()
+        if: ${{ !cancelled() }}
         uses: pmeier/pytest-results-action@main
         with:
           path: ${{env.TEST_FILE}}.xml
@@ -72,7 +72,7 @@ jobs:
           title: Test results
 
   sanity_testsuite_on_linux:
-    if: always()
+    if: ${{ !cancelled() }}
     needs: [sanity_testsuite_on_mac]
     runs-on: [self-hosted, linux]
     strategy:
@@ -126,7 +126,7 @@ jobs:
       run: pytest --verbose --html=${{env.TEST_FILE}}.html --junit-xml ${{env.TEST_FILE}}.xml -m sanity tests/QA
 
     - name: Upload test file
-      if: always()
+      if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
       with:
         name: ${{env.TEST_FILE}}_results
@@ -137,7 +137,7 @@ jobs:
           assets/style.css
 
     - name: Pretty print test results
-      if: always()
+      if: ${{ !cancelled() }}
       uses: pmeier/pytest-results-action@main
       with:
         path: ${{env.TEST_FILE}}.xml


### PR DESCRIPTION
`if:always()` conditions have previously been implemented in our workflows to make sure test results are uploaded, even if the test job failed. However, they prevent GitHub from cancelling the workflow. This PR allows cancelling GitHub workflows, while keeping the uploading if failed behavior. This is the [recommended fix in GitHub documentation](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#always)
