### PR TITLE
remove scheduled updates crazyswarm2

### DIFF
--- a/.github/workflows/crazyswarm2-malmö.yml
+++ b/.github/workflows/crazyswarm2-malmö.yml
@@ -3,8 +3,6 @@ name: Crazyswarm2 test 🐝
 # Controls when the action will run.
 on:
   workflow_dispatch:
-  schedule:
-  - cron:  '0 4 * * *'
 
 jobs:
   cs2_at_crazylab:


### PR DESCRIPTION
It's best to remove the schedule here and reenable it once there is a clearer idea of how much of Crazyswarm2 testing we'd like to do at the office. Currently this test doesn't catch enough of the cases to make it useful