### PR TITLE
Use default latency implementation for latency test

### DIFF
--- a/requirements/communication.toml
+++ b/requirements/communication.toml
@@ -1,16 +1,9 @@
 [requirement.radio]
 description = "These requirements targets the low level radio communication."
 
-[requirement.radio.latencysmall]
-description = "Link round-trip latency for small radio packets (4 bytes)"
+[requirement.radio.latency]
+description = "Link round-trip latency for radio packets"
 rational = "Empirical"
-packet_size = 4
-limit_high_ms = 8
-
-[requirement.radio.latencybig]
-description = "Link round-trip latency for small radio packets (28 bytes)"
-rational = "Empirical"
-packet_size = 28
 limit_high_ms = 8
 
 [requirement.radio.bwsmall]

--- a/tests/QA/test_radio.py
+++ b/tests/QA/test_radio.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 class TestRadio:
     def test_latency_small_packets(self, dev: conftest.BCDevice):
         requirement = conftest.get_requirement('radio.latency')
-        assert(latency(dev.link_uri) < requirement['limit_high_ms'])
+        assert(latency(dev.link_uri, dev.cf) < requirement['limit_high_ms'])
 
     @pytest.mark.requirements("syslink_flowctrl")
     def test_bandwidth_small_packets(self, dev: conftest.BCDevice):
@@ -49,12 +49,13 @@ class TestRadio:
         bandwidth(dev.link_uri, 4, requirement['limit_low'])
 
 
-def latency(uri, timeout=10):
+def latency(uri, cf, timeout=10):
     """
     Retrieve the latency to a Crazyflie.
 
     Args:
         uri (str): The URI of the Crazyflie.
+        cf (Crazyflie): The Crazyflie instance to retrieve the latency from.
         timeout (float): Maximum time to wait for latency updates.
 
     Returns:
@@ -63,7 +64,7 @@ def latency(uri, timeout=10):
     Raises:
         TimeoutError: If the timeout is reached during latency retrieval.
     """
-    with ValidatedSyncCrazyflie(uri) as scf:
+    with ValidatedSyncCrazyflie(uri, cf) as scf:
         syncer = Syncer()
 
         def on_latency_update(latency):


### PR DESCRIPTION
Since [crazyflie-lib-python#492](https://github.com/bitcraze/crazyflie-lib-python/pull/492), there is a default implementation in the library for latency using the echo channel.

The latency testing implementation in this repository conflicts with the new library implementation because it also uses the echo channel but assumes exclusive control of it (no header checks or similar safeguards). This causes occasional failures in the current latency tests when one of the new implementation's latency pings is read by the current test instead. Examples of these failures can be seen here:
[Run 1](https://github.com/bitcraze/crazyflie-testing/actions/runs/12644063536)
[Run 2](https://github.com/bitcraze/crazyflie-testing/actions/runs/12554551217)

This PR fixes the issue by using the latency values provided by the new default latency implementation rather than the custom implementation.

One side effect is that we can no longer differentiate between large and small packet latency, as the new implementation uses fixed-size packets. However, we have not observed any significant difference between these in practice.