### PR TITLE
Add test rig manager to the mac site

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -79,7 +79,7 @@ class BCDevice:
         self.link_uri = device['radio']
 
         self.usb_power_control = self._parse_usb_power_control(device)
-
+        self.power_manager = None
         try:
             self.bl_link_uri = device['bootloader_radio']
         except KeyError:

--- a/conftest.py
+++ b/conftest.py
@@ -100,7 +100,7 @@ class BCDevice:
         if 'properties' in device:
             self.properties = device['properties']
         if 'rig_mamagement' in device:
-            self.power_manager = RigManager(device['rig_mamagement'].split(':')[0], int(device['rig_mamagement'].split(':')[1]))
+            self.power_manager = RigManager(device['rig_management'].split(':')[0], int(device['rig_management'].split(':')[1]))
         self.cf = Crazyflie(rw_cache='./cache')
 
         self.cf.console.receivedChar.add_callback(_console_cb)

--- a/conftest.py
+++ b/conftest.py
@@ -158,9 +158,7 @@ class BCDevice:
         link.close()
         return False
 
-    def reboot(self, rig_manager:RigManager):
-        if self.power_manager is not None and rig_manager is not None:
-           rig_manager.restart(self.power_manager)
+    def reboot(self):
         switch = PowerSwitch(self.link_uri)
         switch.stm_power_cycle()
 
@@ -178,7 +176,11 @@ class BCDevice:
 
         return status
 
-    def goto_bootloader(self, rig_manager: RigManager):
+    def power_cycle(self, rig_manager:RigManager=None):
+        if self.power_manager is not None and rig_manager is not None:
+           rig_manager.restart(self.power_manager)
+
+    def goto_bootloader(self, rig_manager: RigManager=None):
         self.bl.close()
         self.bl = Bootloader(self.link_uri)
         if self.power_manager is not None and rig_manager is not None:
@@ -194,7 +196,7 @@ class BCDevice:
             else:
                 targets = []
             try:
-                self.reboot(rig_manager)
+                self.power_cycle(rig_manager)
                 self.bl.flash_full(cf=self.cf, filename=path, progress_cb=progress_cb, targets=targets,
                     enable_console_log=True, warm=True)
             except Exception as e:
@@ -202,7 +204,7 @@ class BCDevice:
                 self.goto_bootloader(rig_manager)
                 self.bl.flash_full(cf=self.cf, filename=path, progress_cb=progress_cb, targets=targets,
                     enable_console_log=True, warm=False)
-                self.reboot(rig_manager)
+                self.power_cycle(rig_manager)
         finally:
             self.bl.close()
             self.bl = Bootloader(self.link_uri)

--- a/management/arduino_power_manager.py
+++ b/management/arduino_power_manager.py
@@ -8,36 +8,32 @@ class RigManager:
 
     def _set_power(self, output: int, state: bool):
         command = f"system:relay{output} {1 if state else 0}\n"
-        print(command)
         self.instrument.write(command.encode('utf-8'))
 
     def _set_button(self, output: int, state: bool):
         command = f"system:do{output} {1 if state else 0}\n"
-        print(command)
         self.instrument.write(command.encode('utf-8'))
 
 
-    def restart(self) -> None:
-        self._set_button(self.address, True)
-        self._set_power(self.address, False)
+    def restart(self,address=0) -> None:
+        self._set_button(address, True)
+        self._set_power(address, False)
         time.sleep(1)
-        self._set_power(self.address, True)
+        self._set_power(address, True)
 
-    def bootloader(self) -> None:
-        self._set_power(self.address, False)
+    def bootloader(self,address=0) -> None:
+        self._set_power(address, False)
         time.sleep(1)
-        self._set_button(self.address, False)
-        self._set_power(self.address, True)
+        self._set_button(address, False)
+        self._set_power(address, True)
         time.sleep(2.5)
-        self._set_button(self.address, True)
+        self._set_button(address, True)
 
-    def close(self):
-        self.instrument.close()
 
 # Test code
 if __name__ == "__main__":
     import time
 
-    rig_manager = RigManager("/dev/ttyACM1")
+    rig_manager = RigManager("/dev/tty.usbmodemF412FA6372CC2")
 
     rig_manager.restart()

--- a/management/arduino_power_manager.py
+++ b/management/arduino_power_manager.py
@@ -1,0 +1,38 @@
+import easy_scpi as scpi
+import time
+
+class PowerManager():
+    def __init__(self, port: str) -> None:
+        if port is None:
+            raise ValueError('Port cannot be None.')
+        self.port = f'ASRL{port}::INSTR'
+        self.inst = scpi.Instrument(self.port,  read_termination='\r\n',  write_termination='\n')
+        
+
+    def power_on(self) -> None:
+        self.inst.connect()
+        self.inst.system.relay0(1)
+        self.inst.disconnect()
+
+    def power_off(self) -> None:
+        self.inst.connect()
+        self.inst.system.relay0(0)
+        self.inst.disconnect()
+
+    def restart(self) -> None:
+        self.inst.connect()
+        self.inst.system.do0(1)
+        self.inst.system.relay0(0)
+        time.sleep(2)
+        self.inst.system.relay0(1)
+
+    def bootloader(self) -> None:
+        self.inst.connect()
+        self.inst.system.do0(1)
+        self.inst.system.relay0(0)
+        time.sleep(1)
+        self.inst.system.do0(0)
+        self.inst.system.relay0(1)
+        time.sleep(2)
+        self.inst.system.do0(1)
+        self.inst.disconnect()

--- a/management/program.py
+++ b/management/program.py
@@ -33,7 +33,7 @@ currentdir = os.path.dirname(os.path.realpath(__file__))
 parentdir = os.path.join(currentdir, '..')
 sys.path.append(parentdir)
 
-from conftest import get_devices  # noqa
+from conftest import get_devices,get_rig_manager  # noqa
 
 logger = logging.getLogger(__name__)
 
@@ -72,13 +72,15 @@ def get_correct_zip(fw_dir: Path, dev: BCDevice) -> Path:
 def program(fw_zip: Path, retries=0) -> bool:
     # Setup the alarm handler and ask the OS to send a SIGALRM to the process after TIMEOUT seconds
     signal.signal(signal.SIGALRM, alarm_handler)
+    rig_manager = get_rig_manager()
+    print(rig_manager)
     for dev in get_devices():
         while True:
             try:
                 signal.alarm(TIMEOUT)
                 print('Programming device: {}'.format(dev))
                 zip = get_correct_zip(fw_zip, dev)
-                dev.flash(zip, progress_cb)
+                dev.flash(zip, progress_cb, rig_manager)
                 signal.alarm(0)
                 break
             except Exception as err:

--- a/management/program.py
+++ b/management/program.py
@@ -103,4 +103,8 @@ if __name__ == "__main__":
     p = parser.parse_args()
 
     if not program(p.file,p.retries):
+        print('Failed to program devices', file=sys.stderr)
         sys.exit(1)
+    else:
+        print('Devices programmed successfully')
+        sys.exit(0)

--- a/management/rig_manager/rig_manager.ino
+++ b/management/rig_manager/rig_manager.ino
@@ -1,0 +1,101 @@
+#include "Arduino.h"
+#include "Vrekrer_scpi_parser.h"
+
+const int RELAYS[] = {2};
+const int N_RELAYS = sizeof(RELAYS)/sizeof(RELAYS[0]);
+int relayStates[N_RELAYS] = {0,};
+
+const int OUTS[] = {8};
+const int N_OUTS = sizeof(OUTS)/sizeof(OUTS[0]);
+int outsStates[N_OUTS] = {0,};
+
+SCPI_Parser my_instrument;
+
+
+void setup() {
+  my_instrument.RegisterCommand(F("*IDN?"), &Identify);
+  my_instrument.SetCommandTreeBase(F("SYSTem"));
+    my_instrument.RegisterCommand(F(":RELAY#"), &SetRelay);
+    my_instrument.RegisterCommand(F(":RELAY#?"), &GetRelay);
+    my_instrument.RegisterCommand(F(":DO#"), &SetOuts);
+    my_instrument.RegisterCommand(F(":DO#?"), &GetOuts);
+
+
+
+  Serial.begin(9600);
+
+  for (int i=0; i<N_RELAYS; i++) {
+    pinMode(RELAYS[i], OUTPUT);
+  }
+
+  for (int i=0; i<N_OUTS; i++) {
+    pinMode(OUTS[i], OUTPUT);
+  }
+}
+
+void Identify(SCPI_C commands, SCPI_P parameters, Stream& interface) {
+  interface.println(F("Bitcraze,Rig Manager,#00," VREKRER_SCPI_VERSION));
+  //*IDN? Suggested return string should be in the following format:
+  // "<vendor>,<model>,<serial number>,<firmware>"
+}
+
+void SetRelay(SCPI_C commands, SCPI_P parameters, Stream& interface) {
+  //Get the numeric suffix/index (if any) from the commands
+  String header = String(commands.Last());
+  header.toUpperCase();
+  int suffix = -1;
+  sscanf(header.c_str(),"%*[RELAY]%u", &suffix);
+
+  if (parameters.Size() > 0 && suffix >= 0 && suffix < N_RELAYS) {
+    relayStates[suffix] = constrain(String(parameters[0]).toInt(), 0, 10);
+    digitalWrite(RELAYS[suffix], relayStates[suffix]);
+  }
+}
+
+void GetRelay(SCPI_C commands, SCPI_P parameters, Stream& interface) {
+  //Get the numeric suffix/index (if any) from the commands
+  String header = String(commands.Last());
+  header.toUpperCase();
+  int suffix = -1;
+  sscanf(header.c_str(),"%*[RELAY]%u", &suffix);
+
+  if(suffix >= 0 && suffix < N_RELAYS) {
+    interface.println(String(relayStates[suffix], DEC));
+  } else {
+    interface.println(String(-1, DEC));
+  }
+  
+}
+
+void SetOuts(SCPI_C commands, SCPI_P parameters, Stream& interface) {
+  //Get the numeric suffix/index (if any) from the commands
+  String header = String(commands.Last());
+  header.toUpperCase();
+  int suffix = -1;
+  sscanf(header.c_str(),"%*[DO]%u", &suffix);
+
+  if (parameters.Size() > 0 && suffix >= 0 && suffix < N_OUTS) {
+    outsStates[suffix] = constrain(String(parameters[0]).toInt(), 0, 10);
+    digitalWrite(OUTS[suffix], outsStates[suffix]);
+  }
+}
+
+void GetOuts(SCPI_C commands, SCPI_P parameters, Stream& interface) {
+  //Get the numeric suffix/index (if any) from the commands
+  String header = String(commands.Last());
+  header.toUpperCase();
+  int suffix = -1;
+  sscanf(header.c_str(),"%*[DO]%u", &suffix);
+
+  if(suffix >= 0 && suffix < N_OUTS) {
+    interface.println(String(outsStates[suffix], DEC));
+  } else {
+    interface.println(String(-1, DEC));
+  }
+  
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+  my_instrument.ProcessInput(Serial, "\n");
+}

--- a/management/rig_manager/rig_manager.ino
+++ b/management/rig_manager/rig_manager.ino
@@ -3,11 +3,11 @@
 
 const int RELAYS[] = {2};
 const int N_RELAYS = sizeof(RELAYS)/sizeof(RELAYS[0]);
-int relayStates[N_RELAYS] = {0,};
+int relayStates[N_RELAYS] = {1,};
 
 const int OUTS[] = {8};
 const int N_OUTS = sizeof(OUTS)/sizeof(OUTS[0]);
-int outsStates[N_OUTS] = {0,};
+int outsStates[N_OUTS] = {1,};
 
 SCPI_Parser my_instrument;
 
@@ -25,11 +25,15 @@ void setup() {
   Serial.begin(9600);
 
   for (int i=0; i<N_RELAYS; i++) {
+    Serial.println("hello\n");
     pinMode(RELAYS[i], OUTPUT);
+    digitalWrite(RELAYS[i],relayStates[i]);
   }
 
   for (int i=0; i<N_OUTS; i++) {
     pinMode(OUTS[i], OUTPUT);
+    digitalWrite(OUTS[i],outsStates[i]);
+    
   }
 }
 

--- a/management/test_power.py
+++ b/management/test_power.py
@@ -1,0 +1,22 @@
+import easy_scpi as scpi
+import time
+
+inst = scpi.Instrument('ASRL/dev/ttyACM0::INSTR',  read_termination='\r\n',  write_termination='\n')
+
+inst.connect()
+
+inst.system.relay0(0)
+time.sleep(2)
+
+inst.system.do0(0)
+inst.system.relay0(1)
+
+time.sleep(2.5)
+
+inst.system.do0(1)
+
+
+time.sleep(20)
+inst.system.relay0(0)
+
+print(inst.system.relay0())

--- a/management/test_power.py
+++ b/management/test_power.py
@@ -19,12 +19,14 @@ class RigManager:
 if __name__ == "__main__":
     import time
 
-    rig_manager = RigManager("/dev/ttyACM1")
+    rig_manager = RigManager("/dev/tty.usbmodemF412FA6372CC2")
+    if rig_manager is None:
+        raise Exception
 
     # Reset Crazyflie to bootloader mode
-    rig_manager.set_power(0, False)
+    rig_manager._set_power(0, False)
     time.sleep(1)
-    rig_manager.set_button(0, True)
-    rig_manager.set_power(0, True)
+    rig_manager._set_button(0, True)
+    rig_manager._set_power(0, True)
     time.sleep(2.5)
-    rig_manager.set_button(0, False)
+    rig_manager._set_button(0, False)

--- a/management/test_power.py
+++ b/management/test_power.py
@@ -1,22 +1,30 @@
-import easy_scpi as scpi
-import time
-
-inst = scpi.Instrument('ASRL/dev/ttyACM0::INSTR',  read_termination='\r\n',  write_termination='\n')
-
-inst.connect()
-
-inst.system.relay0(0)
-time.sleep(2)
-
-inst.system.do0(0)
-inst.system.relay0(1)
-
-time.sleep(2.5)
-
-inst.system.do0(1)
+import serial
 
 
-time.sleep(20)
-inst.system.relay0(0)
+class RigManager:
+    def __init__(self, port):
+        self.instrument = serial.Serial(port, 9600)
 
-print(inst.system.relay0())
+    def _set_power(self, output: int, state: bool):
+        command = f"system:relay{output} {1 if state else 0}\n"
+        print(command)
+        self.instrument.write(command.encode('utf-8'))
+
+    def _set_button(self, output: int, state: bool):
+        command = f"system:do{output} {0 if state else 1}\n"
+        print(command)
+        self.instrument.write(command.encode('utf-8'))
+
+# Test code
+if __name__ == "__main__":
+    import time
+
+    rig_manager = RigManager("/dev/ttyACM1")
+
+    # Reset Crazyflie to bootloader mode
+    rig_manager.set_power(0, False)
+    time.sleep(1)
+    rig_manager.set_button(0, True)
+    rig_manager.set_power(0, True)
+    time.sleep(2.5)
+    rig_manager.set_button(0, False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 toml
 pytest-html
-pyvisa-py
-easy_scpi
+pyserial

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 toml
 pytest-html
+pyvisa-py
+easy_scpi

--- a/sites/crazylab-mac.toml
+++ b/sites/crazylab-mac.toml
@@ -3,4 +3,5 @@ version = 1
 [device.cf21_stock]
 radio = "radio://0/50/2M/E7E7E71801"
 bootloader_radio = "radio://0/0/2M/B1C5DD7C7F?safelink=0"
+power_manager_port= "/dev/tty.usbmodemF412FA6372CC2"
 

--- a/sites/crazylab-mac.toml
+++ b/sites/crazylab-mac.toml
@@ -3,5 +3,5 @@ version = 1
 [device.cf21_stock]
 radio = "radio://0/50/2M/E7E7E71801"
 bootloader_radio = "radio://0/0/2M/B1C5DD7C7F?safelink=0"
-power_manager_port= "/dev/cu.usbmodemF412FA6372CC2"
+rig_management= "/dev/tty.usbmodemF412FA6372CC2:0"
 

--- a/sites/crazylab-mac.toml
+++ b/sites/crazylab-mac.toml
@@ -1,7 +1,8 @@
 version = 1
+rig_management = "/dev/tty.usbmodemF412FA6372CC2"
 
 [device.cf21_stock]
 radio = "radio://0/50/2M/E7E7E71801"
 bootloader_radio = "radio://0/0/2M/B1C5DD7C7F?safelink=0"
-rig_management= "/dev/tty.usbmodemF412FA6372CC2:0"
+rig_management_addr= "0"
 

--- a/sites/crazylab-mac.toml
+++ b/sites/crazylab-mac.toml
@@ -3,5 +3,5 @@ version = 1
 [device.cf21_stock]
 radio = "radio://0/50/2M/E7E7E71801"
 bootloader_radio = "radio://0/0/2M/B1C5DD7C7F?safelink=0"
-power_manager_port= "/dev/tty.usbmodemF412FA6372CC2"
+power_manager_port= "/dev/cu.usbmodemF412FA6372CC2"
 


### PR DESCRIPTION
This will add a rig manager (an arduino connected to reset interrupt pin and power on the crazyflie).

This way it can be recovered if needed by resetting it to bootloader. 

The rig manager belongs to the entire site but the address is different for every crazyflie depending on what pin on the arduino its connected to.

Before every flashing it will power cycle if there is a rigmanager attached. If not possible to flash then reset the device to bootloader and try cold flash