### PR TITLE
Test to input string types and validate they are set as ints.

### DIFF
--- a/tests/QA/test_param.py
+++ b/tests/QA/test_param.py
@@ -346,8 +346,8 @@ class TestParameters:
             scf.cf.param.add_update_callback(group=group, name=name, cb=param_cb)
 
             scf.cf.param.set_value(param, 2)
-            scf.cf.param.set_value(param, 1)
-            scf.cf.param.set_value(param, 2)
+            scf.cf.param.set_value(param, '1')
+            scf.cf.param.set_value(param, '2')
             scf.cf.param.set_value(param, 1)
 
             scf.cf.param.set_value(param, int(initial))


### PR DESCRIPTION
This was reported an issue in #455 but seems to be fixed. This test validates this fix