### PR TITLE
Use the reliability test to test max size packets

### DIFF
--- a/requirements/communication.toml
+++ b/requirements/communication.toml
@@ -30,9 +30,7 @@ limit_low = 350
 description = "Packet exchange without any information loss"
 rational = "Design"
 background = """
-The design is that there should never be any packet loss ever. So we should be
-able to exchange an infinit amount of packet.
-However, testing infinity is hard so, as a compromise, we are testing on
-30 000 packets which takes ~= 30s to test.
+We are pinging the Crazyflie with the max size packet and never loose any data
 """
-limit_low = 30_000   # It is hard to test infinity ....
+limit_low = 1000
+packet_size = 30

--- a/tests/QA/test_radio.py
+++ b/tests/QA/test_radio.py
@@ -152,10 +152,7 @@ def ping(uri, packet_size=4, count=500):
             # make sure we actually received the expected value
             assert(pk.data == pk_ack.data)
 
-    except Exception as e:
+    finally:
         link.close()
-        raise e
-
-    link.close()
 
     return True


### PR DESCRIPTION
This test should test to ping the crazyflie with the max size packet and always get the data back.

Testing this PR https://github.com/bitcraze/crazyflie-firmware/pull/1460.