### PR TITLE
Fix for not generating 1k number of threads

### DIFF
--- a/.github/workflows/crazylab-linux-experiment.yml
+++ b/.github/workflows/crazylab-linux-experiment.yml
@@ -18,6 +18,10 @@ on:
         type: boolean
         required: false
         default: false
+      lib_version:
+        description: 'Lib version to use'
+        type: string
+        default: 'master'
 
 #  schedule:
 #  - cron:  '0 6 * * *'
@@ -49,7 +53,7 @@ jobs:
             pip3 install pytest-timeout
 
       - name: Install Crazyflie python library
-        run: pip3 install git+https://github.com/bitcraze/crazyflie-lib-python.git@master
+        run: pip3 install git+https://github.com/bitcraze/crazyflie-lib-python.git@${{github.event.inputs.lib_version}}
 
       - name: Check out sources
         uses: actions/checkout@v4

--- a/conftest.py
+++ b/conftest.py
@@ -45,7 +45,7 @@ def pytest_generate_tests(metafunc):
         if fixture == 'request':
             continue
         if devices:
-            metafunc.parametrize(fixture, devices, indirect=(fixture=='test_setup') , ids=lambda d: d.name)
+            metafunc.parametrize(fixture, devices, indirect=(fixture==fixture) , ids=lambda d: d.name)
         else:
             print(f'No devices found for test {metafunc.definition.name}')
             metafunc.parametrize(fixture, [pytest.param(None, marks=pytest.mark.ignore(reason="No device for test"))]) #This is a bit overly complicated but pytest.skip will skip all tests in modul
@@ -313,6 +313,11 @@ def test_setup(request):
     yield fix  # code after this point will run as teardown after test
     fix.close()
 
+@pytest.fixture
+def bl_test_setup(request):
+    device = request.param
+    device.start()
+    yield device  # code after this point will run as teardown after test
 
 def get_bl_address(dev: BCDevice) -> str:
     '''

--- a/conftest.py
+++ b/conftest.py
@@ -119,6 +119,9 @@ class BCDevice:
             self.properties = device['properties']
         if 'rig_management_addr' in device:
             self.power_manager = device['rig_management_addr']
+
+
+    def start(self):
         self.cf = Crazyflie(rw_cache='./cache')
 
         self.cf.console.receivedChar.add_callback(_console_cb)
@@ -277,6 +280,7 @@ class BCDevice:
 
 class DeviceFixture:
     def __init__(self, dev: BCDevice):
+        dev.start()
         self._device = dev
 
     @property
@@ -298,12 +302,17 @@ class DeviceFixture:
             return all(deck in loco_decks for deck in self._device.decks)
         return False
 
+    def close(self):
+        if self._device is not None:
+            self._device.cf.close_link()
+            self._device = None
+
 @pytest.fixture
 def test_setup(request):
     ''' This code will run before (and after) a test '''
     fix = DeviceFixture(request.param)
     yield fix  # code after this point will run as teardown after test
-    fix.device.cf.close_link()
+    fix.close()
 
 
 def get_bl_address(dev: BCDevice) -> str:

--- a/conftest.py
+++ b/conftest.py
@@ -314,7 +314,7 @@ def test_setup(request):
     fix.close()
 
 @pytest.fixture
-def bl_test_setup(request):
+def dev(request):
     device = request.param
     device.start()
     yield device  # code after this point will run as teardown after test

--- a/conftest.py
+++ b/conftest.py
@@ -161,7 +161,6 @@ class BCDevice:
                 link.close()
                 return True
 
-        link.close()
         return False
 
     def reboot(self):
@@ -347,7 +346,6 @@ def get_bl_address(dev: BCDevice) -> str:
             address = 'B1' + binascii.hexlify(pk.data[2:6][::-1]).upper().decode('utf8')  # noqa
             break
 
-    link.close()
     return address
 
 

--- a/management/program.py
+++ b/management/program.py
@@ -75,6 +75,7 @@ def program(fw_zip: Path, retries=0) -> bool:
     rig_manager = get_rig_manager()
     print(rig_manager)
     for dev in get_devices():
+        dev.start()
         while True:
             try:
                 signal.alarm(TIMEOUT)

--- a/tests/QA/test_bootloaders.py
+++ b/tests/QA/test_bootloaders.py
@@ -30,12 +30,11 @@ class TestBootloaders:
 
         dev.bl.close()
 
-    def test_bootloader_reset_simple(self, dev: conftest.BCDevice):
-        self.bootloader_back_and_forth(dev)
+    def test_bootloader_reset_simple(self, bl_test_setup: conftest.BCDevice):
+        self.bootloader_back_and_forth(bl_test_setup)
 
     @pytest.mark.timeout(240)
-    @pytest.mark.exclude_decks('bcAI')
-    def test_bootloader_reset_stress(self, dev: conftest.BCDevice):
+    def test_bootloader_reset_stress(self, bl_test_setup: conftest.BCDevice):
        requirement = conftest.get_requirement('bootloaders.reliability')
        for _ in range(0, requirement['iterations']):
-           self.bootloader_back_and_forth(dev)
+           self.bootloader_back_and_forth(bl_test_setup)

--- a/tests/QA/test_bootloaders.py
+++ b/tests/QA/test_bootloaders.py
@@ -30,11 +30,11 @@ class TestBootloaders:
 
         dev.bl.close()
 
-    def test_bootloader_reset_simple(self, bl_test_setup: conftest.BCDevice):
-        self.bootloader_back_and_forth(bl_test_setup)
+    def test_bootloader_reset_simple(self, dev: conftest.BCDevice):
+        self.bootloader_back_and_forth(dev)
 
     @pytest.mark.timeout(240)
-    def test_bootloader_reset_stress(self, bl_test_setup: conftest.BCDevice):
+    def test_bootloader_reset_stress(self, dev: conftest.BCDevice):
        requirement = conftest.get_requirement('bootloaders.reliability')
        for _ in range(0, requirement['iterations']):
-           self.bootloader_back_and_forth(bl_test_setup)
+           self.bootloader_back_and_forth(dev)


### PR DESCRIPTION
We used to generate to many threads when creating Crazyflie objects at every bcdevice instance. 

To mitigate this there is now a start() function to do something with the device except just getting data from it. 

It should help the issue where the testing just hangs because of too many active threads. 
However there will/should also be a fix for actually closing the ParamUpdater threads properly.
Right now they will live forever, but i have not yet found a good fix, since we seem to be relying on this bug in many places.