### PR TITLE
Fail bootloader reset tests on firmware asserts

### DIFF
--- a/requirements/bootloaders.toml
+++ b/requirements/bootloaders.toml
@@ -23,3 +23,4 @@ However, testing infinity is hard so, as a compromise, we are testing with
 20 iterations per device.
 """
 iterations = 20
+timeout_per_iteration = 12

--- a/tests/QA/test_bootloaders.py
+++ b/tests/QA/test_bootloaders.py
@@ -17,9 +17,7 @@ import time
 from conftest import BCDevice
 
 
-
 class TestBootloaders:
-
     @staticmethod
     def bootloader_back_and_forth(dev: BCDevice):
         # The start_bootloader method only returns true if it can communicate with the bootloader.
@@ -31,11 +29,21 @@ class TestBootloaders:
 
         dev.bl.close()
 
+    @pytest.mark.timeout(
+        conftest.get_requirement("bootloaders.reliability")["timeout_per_iteration"]
+    )
     def test_bootloader_reset_simple(self, unconnected_bc_dev: BCDevice):
         self.bootloader_back_and_forth(unconnected_bc_dev)
+        assert unconnected_bc_dev.connect_sync()
 
-    @pytest.mark.timeout(240)
+    @pytest.mark.timeout(
+        conftest.get_requirement("bootloaders.reliability")["iterations"]
+        * conftest.get_requirement("bootloaders.reliability")["timeout_per_iteration"]
+    )
     def test_bootloader_reset_stress(self, unconnected_bc_dev: BCDevice):
-       requirement = conftest.get_requirement('bootloaders.reliability')
-       for _ in range(0, requirement['iterations']):
-           self.bootloader_back_and_forth(unconnected_bc_dev)
+        requirement = conftest.get_requirement("bootloaders.reliability")
+        iterations = requirement["iterations"]
+
+        for _ in range(0, iterations):
+            self.bootloader_back_and_forth(unconnected_bc_dev)
+        assert unconnected_bc_dev.connect_sync()


### PR DESCRIPTION
Update `test_bootloaders.py` so that a
full connection check is performed at the end of the tests. This makes the test fail when a firmware assert occurs, surfacing the problem in the correct place rather than letting it slip through and cause later test failures.